### PR TITLE
Map objectives, handle null/empty/invalid, improve speed/routing, add flags

### DIFF
--- a/src/main/java/org/sitenv/referenceccda/validators/RefCCDAValidationResult.java
+++ b/src/main/java/org/sitenv/referenceccda/validators/RefCCDAValidationResult.java
@@ -1,6 +1,7 @@
 package org.sitenv.referenceccda.validators;
 
 import org.sitenv.referenceccda.validators.enums.ValidationResultType;
+import org.sitenv.referenceccda.validators.schema.MDHTResultDetails;
 
 public class RefCCDAValidationResult {
 
@@ -10,7 +11,7 @@ public class RefCCDAValidationResult {
 	private final String xPath;
     private final String validatorConfiguredXpath;
 	private final String documentLineNumber;
-	private final boolean isSchemaError, isDataTypeSchemaError;
+    private final MDHTResultDetails mdhtResultDetails;
 
 	// Only valid for Vocabulary testing
 	private String actualCode;
@@ -28,8 +29,7 @@ public class RefCCDAValidationResult {
         this.actualCodeSystem = builder.actualCodeSystem;
         this.actualCodeSystemName = builder.actualCodeSystemName;
         this.actualDisplayName = builder.actualDisplayName;
-        this.isSchemaError = builder.isSchemaError;
-        this.isDataTypeSchemaError = builder.isDataTypeSchemaError;
+        this.mdhtResultDetails = builder.mdhtResultDetails;
     }
 
     public String getDescription() {
@@ -53,12 +53,20 @@ public class RefCCDAValidationResult {
     }
     
     public boolean isSchemaError() {
-    	return isSchemaError;
+    	return mdhtResultDetails.isSchemaError();
     }
     
     public boolean isDataTypeSchemaError() {
-    	return isDataTypeSchemaError;
+    	return mdhtResultDetails.isDataTypeSchemaError();
     }
+    
+	public boolean isIGIssue() {
+		return mdhtResultDetails.isIGIssue();
+	}
+
+	public boolean isMUIssue() {
+		return mdhtResultDetails.isMUIssue();
+	}    
 
     public String getActualCodeSystem() {
         return actualCodeSystem;
@@ -84,7 +92,7 @@ public class RefCCDAValidationResult {
         private final String xPath;
         private final String validatorConfiguredXpath;
         private final String documentLineNumber;
-        private final boolean isSchemaError, isDataTypeSchemaError;         
+        private final MDHTResultDetails mdhtResultDetails;
 
         // Only valid for Vocabulary testing
         private String actualCodeSystem;
@@ -93,16 +101,14 @@ public class RefCCDAValidationResult {
         private String actualCodeSystemName;
 
 		public RefCCDAValidationResultBuilder(String description, String xPath,
-				String validatorConfiguredXpath, ValidationResultType type,
-				String documentLineNumber, boolean isSchemaError,
-				boolean isDataTypeSchemaError) {
+				String validatorConfiguredXpath, ValidationResultType type, String documentLineNumber, 
+				MDHTResultDetails mdhtResultDetails) {
 			this.description = description;
 			this.validatorConfiguredXpath = validatorConfiguredXpath;
 			this.type = type;
 			this.xPath = xPath;
 			this.documentLineNumber = documentLineNumber;
-			this.isSchemaError = isSchemaError;
-			this.isDataTypeSchemaError = isDataTypeSchemaError;
+			this.mdhtResultDetails = mdhtResultDetails;
 		}
 
         public RefCCDAValidationResultBuilder actualCodeSystem(String actualCodeSystem) {

--- a/src/main/java/org/sitenv/referenceccda/validators/content/ReferenceContentValidator.java
+++ b/src/main/java/org/sitenv/referenceccda/validators/content/ReferenceContentValidator.java
@@ -6,6 +6,7 @@ import org.sitenv.referenceccda.validators.BaseCCDAValidator;
 import org.sitenv.referenceccda.validators.CCDAValidator;
 import org.sitenv.referenceccda.validators.RefCCDAValidationResult;
 import org.sitenv.referenceccda.validators.enums.ValidationResultType;
+import org.sitenv.referenceccda.validators.schema.MDHTResultDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.xml.sax.SAXException;
@@ -54,8 +55,9 @@ public class ReferenceContentValidator extends BaseCCDAValidator implements CCDA
             default: type = ValidationResultType.REF_CCDA_INFO;
                 break;
         }
-
-        return new RefCCDAValidationResult.RefCCDAValidationResultBuilder(result.getMessage(), null, null, type, "0", false, false)
+        
+        return new RefCCDAValidationResult.RefCCDAValidationResultBuilder(result.getMessage(), null, null, type, "0", 
+        		new MDHTResultDetails(false, false, false, false))
                 .build();
     }
 }

--- a/src/main/java/org/sitenv/referenceccda/validators/schema/CCDATypes.java
+++ b/src/main/java/org/sitenv/referenceccda/validators/schema/CCDATypes.java
@@ -1,5 +1,9 @@
 package org.sitenv.referenceccda.validators.schema;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public final class CCDATypes {
 	// higher level validation versions - not an objective
 	public static final String CCDAR21_OR_CCDAR11 = "C-CDA R2.1 or R1.1 Document";
@@ -9,15 +13,21 @@ public final class CCDATypes {
 	// generic CCDA base level
 	public static final String NON_SPECIFIC_CCDA = "NonSpecificCCDA";
 	public static final String NON_SPECIFIC_CCDAR2 = "NonSpecificCCDAR2";
+	public static final List<String> NON_SPECIFIC_CCDA_TYPES = new ArrayList<String>(
+			Arrays.asList(NON_SPECIFIC_CCDA, NON_SPECIFIC_CCDAR2));
 
 	// most common mu2
 	public static final String TRANSITIONS_OF_CARE_AMBULATORY_SUMMARY = "TransitionsOfCareAmbulatorySummary";
-
 	// other mu2
 	public static final String CLINICAL_OFFICE_VISIT_SUMMARY = "ClinicalOfficeVisitSummary";
 	public static final String TRANSITIONS_OF_CARE_INPATIENT_SUMMARY = "TransitionsOfCareInpatientSummary";
 	public static final String VDT_AMBULATORY_SUMMARY = "VDTAmbulatorySummary";
 	public static final String VDT_INPATIENT_SUMMARY = "VDTInpatientSummary";
+	public static final List<String> MU2_TYPES = new ArrayList<String>(
+			Arrays.asList(TRANSITIONS_OF_CARE_AMBULATORY_SUMMARY,
+					CLINICAL_OFFICE_VISIT_SUMMARY,
+					TRANSITIONS_OF_CARE_INPATIENT_SUMMARY,
+					VDT_AMBULATORY_SUMMARY, VDT_INPATIENT_SUMMARY));
 
 	// CCDA document level (non-mu2)
 	public static final String CONSULTATION_NOTE = "ConsultationNote";
@@ -29,4 +39,16 @@ public final class CCDATypes {
 	public static final String PROCEDURE_NOTE = "ProcedureNote";
 	public static final String PROGRESS_NOTE = "ProgressNote";
 	public static final String UNSTRUCTURED_DOCUMENT = "UnstructuredDocument";
+	
+	public static String getTypes() {
+		StringBuffer sb = new StringBuffer();
+		ValidationObjectives.appendObjectivesData(NON_SPECIFIC_CCDA_TYPES, "LEGACY (same result as 'C-CDA_IG_Plus_Vocab')", sb);
+		sb.append(" ");
+		ValidationObjectives.appendObjectivesData(MU2_TYPES, "C-CDA R1.1 WITH MU2", sb);
+		return sb.toString();
+	}
+	
+	public static void main(String[] args) {
+		System.out.println(CCDATypes.getTypes());
+	}
 }

--- a/src/main/java/org/sitenv/referenceccda/validators/schema/MDHTResultDetails.java
+++ b/src/main/java/org/sitenv/referenceccda/validators/schema/MDHTResultDetails.java
@@ -1,0 +1,45 @@
+package org.sitenv.referenceccda.validators.schema;
+
+public class MDHTResultDetails {
+	private boolean isSchemaError, isDataTypeSchemaError, isIGIssue, isMUIssue;
+	
+	public MDHTResultDetails(boolean isSchemaError, boolean isDataTypeSchemaError, 
+			boolean isIGIssue, boolean isMUIssue) {
+		this.isSchemaError = isSchemaError;
+		this.isDataTypeSchemaError = isDataTypeSchemaError;
+		this.isIGIssue = isIGIssue;
+		this.isMUIssue = isMUIssue;
+	}
+
+	public boolean isSchemaError() {
+		return isSchemaError;
+	}
+
+	public void setSchemaError(boolean isSchemaError) {
+		this.isSchemaError = isSchemaError;
+	}
+
+	public boolean isDataTypeSchemaError() {
+		return isDataTypeSchemaError;
+	}
+
+	public void setDataTypeSchemaError(boolean isDataTypeSchemaError) {
+		this.isDataTypeSchemaError = isDataTypeSchemaError;
+	}
+
+	public boolean isIGIssue() {
+		return isIGIssue;
+	}
+
+	public void setIGIssue(boolean isIGIssue) {
+		this.isIGIssue = isIGIssue;
+	}
+
+	public boolean isMUIssue() {
+		return isMUIssue;
+	}
+
+	public void setMUIssue(boolean isMUIssue) {
+		this.isMUIssue = isMUIssue;
+	}
+}

--- a/src/main/java/org/sitenv/referenceccda/validators/schema/ReferenceCCDAValidator.java
+++ b/src/main/java/org/sitenv/referenceccda/validators/schema/ReferenceCCDAValidator.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.emf.ecore.EClass;
@@ -28,7 +29,10 @@ import org.xml.sax.SAXException;
 @Component
 public class ReferenceCCDAValidator extends BaseCCDAValidator implements CCDAValidator {
 	private static Logger logger = Logger.getLogger(ReferenceCCDAValidator.class);
-
+	
+	private static final String IG_ISSUE_ID = "a.consol", MU_ISSUE_ID = "a.mu2con";
+	private boolean isValidationObjectiveMu2Type = false;
+	
 	public ArrayList<RefCCDAValidationResult> validateFile(String validationObjective,
 			String referenceFileName, String ccdaFile) throws SAXException, Exception {
 		final XPathIndexer xpathIndexer = new XPathIndexer();
@@ -49,35 +53,103 @@ public class ReferenceCCDAValidator extends BaseCCDAValidator implements CCDAVal
 				}
 			}
 		}
+		if(result.getAllDiagnostics().isEmpty()) {
+			logAndThrowException("The MDHT ValidationResult object was not populated for an unknown reason.");
+		}
+		logger.info("Processing and returning MDHT validation results");
 		return processValidationResults(xpathIndexer, result);
 	}
 
-	private static void validateDocumentByTypeUsingMDHTApi(InputStream in, String validationObjective, 
-			ValidationResult result) throws Exception{	
-		if (validationObjective.equalsIgnoreCase(CCDATypes.NON_SPECIFIC_CCDAR2) || 
-				validationObjective.equalsIgnoreCase(CCDATypes.NON_SPECIFIC_CCDA)) {
-			Mu2consolPackage.eINSTANCE.unload();
-			ConsolPackage.eINSTANCE.eClass();
-			logger.info("Loading valdationObjective: " + validationObjective);
-			CDAUtil.load(in, result);
-		} else {
-			Mu2consolPackage.eINSTANCE.reload();
-			Mu2consolPackage.eINSTANCE.eClass();
-			EClass docType = null;
-			if (validationObjective.equalsIgnoreCase(CCDATypes.CLINICAL_OFFICE_VISIT_SUMMARY)) {
-				docType = Mu2consolPackage.eINSTANCE.getClinicalOfficeVisitSummary();
-			} else if (validationObjective.equalsIgnoreCase(CCDATypes.TRANSITIONS_OF_CARE_AMBULATORY_SUMMARY)) {
-				docType = Mu2consolPackage.eINSTANCE.getTransitionOfCareAmbulatorySummary();
-			} else if (validationObjective.equalsIgnoreCase(CCDATypes.TRANSITIONS_OF_CARE_INPATIENT_SUMMARY)) {
-				docType = Mu2consolPackage.eINSTANCE.getTransitionOfCareInpatientSummary();
-			} else if (validationObjective.equalsIgnoreCase(CCDATypes.VDT_AMBULATORY_SUMMARY)) {
-				docType = Mu2consolPackage.eINSTANCE.getVDTAmbulatorySummary();
-			} else if (validationObjective.equalsIgnoreCase(CCDATypes.VDT_INPATIENT_SUMMARY)) {
-				docType = Mu2consolPackage.eINSTANCE.getVDTInpatientSummary();
-			}
-			logger.info("Loading valdationObjective: " + validationObjective + " as MU2 docType: " + docType.getName());
-			CDAUtil.loadAs(in, docType, result);
+	private void validateDocumentByTypeUsingMDHTApi(InputStream in, String validationObjective, 
+			ValidationResult result) throws Exception {
+		if(StringUtils.isEmpty(validationObjective)) {
+			logAndThrowException("The validationObjective given is " + (validationObjective == null ? "null" : "empty"),
+					"The validationObjective given was null or empty. Please try one of the following valid Strings instead: "
+					+ ValidationObjectives.getObjectives() + " " + CCDATypes.getTypes());
 		}
+		
+		String mdhtValidationObjective = mapMdhtValidationObjective(validationObjective);
+		logger.info("Mapped mdhtValidationObjective: " + (mdhtValidationObjective != null ? mdhtValidationObjective : "null objective"));
+		if(mdhtValidationObjective != null) {
+			//populate the field for reuse
+			isValidationObjectiveMu2Type = isValidationObjectiveMu2Type(mdhtValidationObjective);
+			if (isValidationObjectiveCCDAType(mdhtValidationObjective)) {
+				Mu2consolPackage.eINSTANCE.unload();
+				ConsolPackage.eINSTANCE.eClass();
+				logger.info("Loading mdhtValidationObjective: " + mdhtValidationObjective
+						+ " mapped from valdationObjective: " + validationObjective);
+				CDAUtil.load(in, result);
+			} else if (isValidationObjectiveMu2Type) {
+				Mu2consolPackage.eINSTANCE.reload();
+				Mu2consolPackage.eINSTANCE.eClass();
+				EClass docType = null;
+				if (mdhtValidationObjective.equalsIgnoreCase(CCDATypes.CLINICAL_OFFICE_VISIT_SUMMARY)) {
+					docType = Mu2consolPackage.eINSTANCE.getClinicalOfficeVisitSummary();
+				} else if (mdhtValidationObjective.equalsIgnoreCase(CCDATypes.TRANSITIONS_OF_CARE_AMBULATORY_SUMMARY)) {
+					docType = Mu2consolPackage.eINSTANCE.getTransitionOfCareAmbulatorySummary();
+				} else if (mdhtValidationObjective.equalsIgnoreCase(CCDATypes.TRANSITIONS_OF_CARE_INPATIENT_SUMMARY)) {
+					docType = Mu2consolPackage.eINSTANCE.getTransitionOfCareInpatientSummary();
+				} else if (mdhtValidationObjective.equalsIgnoreCase(CCDATypes.VDT_AMBULATORY_SUMMARY)) {
+					docType = Mu2consolPackage.eINSTANCE.getVDTAmbulatorySummary();
+				} else if (mdhtValidationObjective.equalsIgnoreCase(CCDATypes.VDT_INPATIENT_SUMMARY)) {
+					docType = Mu2consolPackage.eINSTANCE.getVDTInpatientSummary();
+				}
+				boolean isDocTypeNull = docType == null || docType.getName() == null;
+				logger.info("Loading mdhtValidationObjective: " + mdhtValidationObjective
+						+ " as MU2 docType: " + (!isDocTypeNull ? docType : "null docType")
+						+ " mapped from valdationObjective: " + validationObjective);
+				if(!isDocTypeNull) {
+					CDAUtil.loadAs(in, docType, result);
+				} else {
+					logAndThrowException("docType == null", "The MU2 docType EClass could not be assigned "
+							+ "from mdhtValidationObjective: " + mdhtValidationObjective);
+				}
+			}
+		} else {
+			logAndThrowException("The validationObjective given is invalid", 
+					"The validationObjective given was invalid. Please try one of the following valid Strings instead: "
+					+ ValidationObjectives.getObjectives() + " " + CCDATypes.getTypes());
+		}
+	}
+	
+	private static String mapMdhtValidationObjective(String validationObjectivePOSTed) throws Exception {
+		if (isValidationObjectiveACertainType(validationObjectivePOSTed, CCDATypes.NON_SPECIFIC_CCDA_TYPES) || 
+				isValidationObjectiveACertainType(validationObjectivePOSTed, CCDATypes.MU2_TYPES)) {
+			// we already have a *specific* MDHT objective (it was sent directly so no re-mapping required)
+			return validationObjectivePOSTed;
+		} else if (isValidationObjectiveACertainType(validationObjectivePOSTed,
+				ValidationObjectives.ALL)) {
+			// convert to a *generic* MDHT objective (runs R2.1 or R1.1 MDHT validation using the consol2 model)
+			return CCDATypes.NON_SPECIFIC_CCDAR2;
+		}
+		logger.warn("An invalid validationObjective was POSTed");
+		return null;
+	}
+	
+	private static void logAndThrowException(String dualErrorMessage) throws Exception {
+		logAndThrowException(dualErrorMessage, dualErrorMessage);
+	}	
+	
+	private static void logAndThrowException(String internalErrorMessage, String userErrorMessage) throws Exception {
+		logger.error(internalErrorMessage);
+		throw new Exception(userErrorMessage);
+	}
+	
+	public static boolean isValidationObjectiveACertainType(String validationObjective, List<String> types) {
+		for(String type: types) {
+			if(validationObjective.equalsIgnoreCase(type)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	private static boolean isValidationObjectiveMu2Type(String validationObjective) {
+		return isValidationObjectiveACertainType(validationObjective, CCDATypes.MU2_TYPES);
+	}
+	
+	private static boolean isValidationObjectiveCCDAType(String validationObjective) {
+		return isValidationObjectiveACertainType(validationObjective, CCDATypes.NON_SPECIFIC_CCDA_TYPES);
 	}
 
 	private ArrayList<RefCCDAValidationResult> processValidationResults(final XPathIndexer xpathIndexer,
@@ -98,28 +170,42 @@ public class ReferenceCCDAValidator extends BaseCCDAValidator implements CCDAVal
 
 	private RefCCDAValidationResult buildValidationResult(Diagnostic diagnostic, XPathIndexer xPathIndexer,
 			ValidationResultType resultType) {
-		boolean isResultIGIssue = false;
-		boolean isResultMUIssue = false;
-		boolean isResultSchemaError = false;
-		boolean isResultDataTypeSchemaError = false;
-		boolean isDocumentSchemaError = false;
 		CDADiagnostic diag = new CDADiagnostic(diagnostic);
 		String lineNumber = getLineNumberInXMLUsingXpath(xPathIndexer, diagnostic);
-		if(resultType == ValidationResultType.CCDA_MDHT_CONFORMANCE_ERROR) {
-			if (diag.getSource() != null) {
-				if (diag.getSource().contains("a.consol")) {
-					isResultIGIssue = true;
+		MDHTResultDetails mdhtResultDetails = populateMDHTResultDetails(diag, resultType);
+		return createNewValidationResult(diag, resultType, lineNumber, mdhtResultDetails);
+	}
+	
+	private MDHTResultDetails populateMDHTResultDetails(CDADiagnostic diag, ValidationResultType resultType) {
+		MDHTResultDetails mdhtResultDetails = new MDHTResultDetails(false, false, false, false);
+		if (diag.getSource() != null) {
+			boolean isIGIssue = diag.getSource().contains(IG_ISSUE_ID);
+			boolean isMUIssue = isValidationObjectiveMu2Type ? diag.getSource().contains(MU_ISSUE_ID) : false;
+			//IG/MU2 - all severities
+			if(resultType == ValidationResultType.CCDA_MDHT_CONFORMANCE_ERROR || 
+					resultType == ValidationResultType.CCDA_MDHT_CONFORMANCE_WARN || 
+					resultType == ValidationResultType.CCDA_MDHT_CONFORMANCE_INFO) {
+				if (isIGIssue) {
+					mdhtResultDetails.setIGIssue(true);
+					return mdhtResultDetails;
+				} else if (isMUIssue) {
+					mdhtResultDetails.setMUIssue(true);
+					return mdhtResultDetails;
 				} else {
-					// javax.xml.validation.Validator, org.eclipse.emf.ecore, etc.
-					isResultSchemaError = true;
-					if (diag.getPath() != null && diag.getCode() > 0) {
-						// org.eclipse.emf.ecore, etc.
-						isResultDataTypeSchemaError = true;
-					}
+					//schema - errors only
+					if(resultType == ValidationResultType.CCDA_MDHT_CONFORMANCE_ERROR) {
+						// javax.xml.validation.Validator, org.eclipse.emf.ecore, etc.
+						mdhtResultDetails.setSchemaError(true);
+						if (diag.getPath() != null && diag.getCode() > 0) {
+							// org.eclipse.emf.ecore, etc.
+							mdhtResultDetails.setDataTypeSchemaError(true);
+							return mdhtResultDetails;
+						}
+					}					
 				}
 			}
 		}
-		return createNewValidationResult(diag, resultType, lineNumber, isResultSchemaError, isResultDataTypeSchemaError);
+		return mdhtResultDetails;
 	}
 
 	private String getLineNumberInXMLUsingXpath(final XPathIndexer xpathIndexer, Diagnostic diagnostic) {
@@ -151,10 +237,8 @@ public class ReferenceCCDAValidator extends BaseCCDAValidator implements CCDAVal
 	}
 
 	private RefCCDAValidationResult createNewValidationResult(CDADiagnostic cdaDiag, ValidationResultType resultType,
-			String resultLineNumber, boolean isResultSchemaError, boolean isResultDataTypeSchemaError) {
+			String resultLineNumber, MDHTResultDetails mdhtResultDetails) {
 		return new RefCCDAValidationResult.RefCCDAValidationResultBuilder(
-				cdaDiag.getMessage(), cdaDiag.getPath(), null, resultType,
-				resultLineNumber, isResultSchemaError,
-				isResultDataTypeSchemaError).build();
+				cdaDiag.getMessage(), cdaDiag.getPath(), null, resultType, resultLineNumber, mdhtResultDetails).build();
 	}
 }

--- a/src/main/java/org/sitenv/referenceccda/validators/schema/ValidationObjectives.java
+++ b/src/main/java/org/sitenv/referenceccda/validators/schema/ValidationObjectives.java
@@ -1,0 +1,96 @@
+package org.sitenv.referenceccda.validators.schema;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public final class ValidationObjectives {
+	public static final List<String> ALL = new ArrayList<String>();
+	static {
+		ALL.addAll(Sender.OBJECTIVES);
+		ALL.addAll(Receiver.OBJECTIVES);
+	}
+	public static final List<String> VALID_CONTENT_OBJECTIVES = new ArrayList<String>(Arrays.asList(
+			Sender.B1_TOC_AMB_170_315, Sender.B1_TOC_INP_170_315, 
+			Sender.B2_CIRI_AMB_170_315, Sender.B2_CIRI_INP_170_315,
+			Sender.B4_CCDS_AMB_170_315, Sender.B4_CCDS_INP_170_315, 
+			Sender.B6_DE_AMB_170_315, Sender.B6_DE_INP_170_315,
+			Sender.B9_CP_AMB_170_315, Sender.B9_CP_INP_170_315, 
+			Sender.E1_VDT_AMB_170_315, Sender.E1_VDT_INP_170_315,
+			Sender.G9_APIACCESS_AMB_170_315, Sender.G9_APIACCESS_INP_170_315));
+
+	public static class Sender {
+		public static final String B1_TOC_AMB_170_315 = "170.315_b1_ToC_Amb";
+		public static final String B1_TOC_INP_170_315 = "170.315_b1_ToC_Inp";
+		public static final String B2_CIRI_AMB_170_315 = "170.315_b2_CIRI_Amb";
+		public static final String B2_CIRI_INP_170_315 = "170.315_b2_CIRI_Inp";
+		public static final String B4_CCDS_AMB_170_315 = "170.315_b4_CCDS_Amb";
+		public static final String B4_CCDS_INP_170_315 = "170.315_b4_CCDS_Inp";
+		public static final String B6_DE_AMB_170_315 = "170.315_b6_DE_Amb";
+		public static final String B6_DE_INP_170_315 = "170.315_b6_DE_Inp";
+		public static final String B7_DS4P_AMB_170_315 = "170.315_b7_DS4P_Amb";
+		public static final String B7_DS4P_INP_170_315 = "170.315_b7_DS4P_Inp";
+		public static final String B9_CP_AMB_170_315 = "170.315_b9_CP_Amb";
+		public static final String B9_CP_INP_170_315 = "170.315_b9_CP_Inp";
+		public static final String E1_VDT_AMB_170_315 = "170.315_e1_VDT_Amb";
+		public static final String E1_VDT_INP_170_315 = "170.315_e1_VDT_Inp";
+		public static final String G9_APIACCESS_AMB_170_315 = "170.315_g9_APIAccess_Amb";
+		public static final String G9_APIACCESS_INP_170_315 = "170.315_g9_APIAccess_Inp";
+		public static final String C_CDA_IG_ONLY = "C-CDA_IG_Only";
+		public static final String C_CDA_IG_PLUS_VOCAB = "C-CDA_IG_Plus_Vocab";
+		public static final String GOLD_SAMPLES_FOR_PRACTICE = "Gold_Samples_For_Practice";
+		public static final List<String> OBJECTIVES = new ArrayList<String>(
+				Arrays.asList(B1_TOC_AMB_170_315, B1_TOC_INP_170_315,
+						B2_CIRI_AMB_170_315, B2_CIRI_INP_170_315,
+						B4_CCDS_AMB_170_315, B4_CCDS_INP_170_315,
+						B6_DE_AMB_170_315, B6_DE_INP_170_315,
+						B7_DS4P_AMB_170_315, B7_DS4P_INP_170_315,
+						B9_CP_AMB_170_315, B9_CP_INP_170_315,
+						E1_VDT_AMB_170_315, E1_VDT_INP_170_315,
+						G9_APIACCESS_AMB_170_315, G9_APIACCESS_INP_170_315,
+						C_CDA_IG_ONLY, C_CDA_IG_PLUS_VOCAB,
+						GOLD_SAMPLES_FOR_PRACTICE));
+	}
+
+	public static class Receiver {
+		public static final String B1_TOC_AMB_170_315 = Sender.B1_TOC_AMB_170_315;
+		public static final String B1_TOC_INP_170_315 = Sender.B1_TOC_INP_170_315;
+		public static final String B2_CIRI_AMB_170_315 = Sender.B2_CIRI_AMB_170_315;
+		public static final String B2_CIRI_INP_170_315 = Sender.B2_CIRI_INP_170_315;
+		public static final String B5_CCDS_AMB_170_315 = "170.315_b5_CCDS_Amb";
+		public static final String B5_CCDS_INP_170_315 = "170.315_b5_CCDS_Inp";
+		public static final String B8_DS4P_AMB_170_315 = "170.315_b8_DS4P_Amb";
+		public static final String B8_DS4P_INP_170_315 = "170.315_b8_DS4P_Inp";
+		public static final String B9_CP_AMB_170_315 = Sender.B9_CP_AMB_170_315;
+		public static final String B9_CP_INP_170_315 = Sender.B9_CP_INP_170_315;
+		public static final String NEGATIVE_TESTING_CCDS = "NegativeTesting_CCDS";
+		public static final String NEGATIVE_TESTING_CAREPLAN = "NegativeTesting_CarePlan";
+		public static final List<String> OBJECTIVES = new ArrayList<String>(
+				Arrays.asList(B1_TOC_AMB_170_315, B1_TOC_INP_170_315,
+						B2_CIRI_AMB_170_315, B2_CIRI_INP_170_315,
+						B5_CCDS_AMB_170_315, B5_CCDS_INP_170_315,
+						B8_DS4P_AMB_170_315, B8_DS4P_INP_170_315,
+						B9_CP_AMB_170_315, B9_CP_INP_170_315,
+						NEGATIVE_TESTING_CCDS, NEGATIVE_TESTING_CAREPLAN));
+	}
+
+	public static String getObjectives() {
+		StringBuffer sb = new StringBuffer();
+		appendObjectivesData(Sender.OBJECTIVES, "SENDER", sb);
+		sb.append(" ");
+		appendObjectivesData(Receiver.OBJECTIVES, "RECEIVER", sb);
+		return sb.toString();
+	}
+	
+	protected static void appendObjectivesData(List<String> objectives, String parentClassName, StringBuffer sb) {
+		sb.append(parentClassName + " options: ");
+		for (int i = 0; i < objectives.size(); i++) {
+			sb.append(objectives.get(i)
+					+ (i == objectives.size() - 1 ? "" : ", "));
+		}
+	}
+
+	public static void main(String[] args) {
+		System.out.println(ValidationObjectives.getObjectives());
+	}
+}

--- a/src/main/java/org/sitenv/referenceccda/validators/vocabulary/VocabularyCCDAValidator.java
+++ b/src/main/java/org/sitenv/referenceccda/validators/vocabulary/VocabularyCCDAValidator.java
@@ -6,6 +6,7 @@ import org.sitenv.referenceccda.validators.CCDAValidator;
 import org.sitenv.referenceccda.validators.RefCCDAValidationResult;
 import org.sitenv.referenceccda.validators.XPathIndexer;
 import org.sitenv.referenceccda.validators.enums.ValidationResultType;
+import org.sitenv.referenceccda.validators.schema.MDHTResultDetails;
 import org.sitenv.vocabularies.validation.dto.VocabularyValidationResult;
 import org.sitenv.vocabularies.validation.services.VocabularyValidationService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,7 +64,8 @@ public class VocabularyCCDAValidator extends BaseCCDAValidator implements CCDAVa
         }
         String lineNumber = getLineNumberInXMLUsingXpath(xpathIndexer, result.getNodeValidationResult().getValidatedDocumentXpathExpression());
 
-        return new RefCCDAValidationResult.RefCCDAValidationResultBuilder(result.getMessage(), result.getNodeValidationResult().getValidatedDocumentXpathExpression(), result.getNodeValidationResult().getConfiguredXpathExpression(), type, lineNumber, false, false)
+        return new RefCCDAValidationResult.RefCCDAValidationResultBuilder(result.getMessage(), result.getNodeValidationResult().getValidatedDocumentXpathExpression(), result.getNodeValidationResult().getConfiguredXpathExpression(), type, lineNumber, 
+        		new MDHTResultDetails(false, false, false, false))
                 .actualCode(result.getNodeValidationResult().getRequestedCode())
                 .actualCodeSystem(result.getNodeValidationResult().getRequestedCodeSystem())
                 .actualCodeSystemName(result.getNodeValidationResult().getRequestedCodeSystemName())


### PR DESCRIPTION
-Enforced valid validation objectives and supply the user with valid
objectives if an invalid one is sent (covers random and empty string
objectives)
-Improved validation speed when running validationObjective
'C-CDA_IG_Only' by not processing vocabulary results in the backend.
e.g. for a 120kb file, improved speed from ~5 seconds to 1/4 second.
-No longer calling Content validation if the the objective is unrelated
or if vocabulary validation is skipped due to the objective sent
-Added flags to JSON results to identify if a result is IG or MU related